### PR TITLE
fix futures api settle_plan type

### DIFF
--- a/src/futures/rest_model.rs
+++ b/src/futures/rest_model.rs
@@ -45,7 +45,7 @@ pub struct Symbol {
     pub quote_precision: u64,
     pub underlying_type: String,
     pub underlying_sub_type: Vec<String>,
-    pub settle_plan: u16,
+    pub settle_plan: u64,
     #[serde(with = "string_or_float")]
     pub trigger_protect: f64,
     pub filters: Vec<Filters>,


### PR DESCRIPTION
Apparently BZRXUSDT has a `settle_plan` of `1639879200000` now (whatever that means, but the deserialization fails because of it).