### PR TITLE
Add serde to KlineSummary

### DIFF
--- a/src/account.rs
+++ b/src/account.rs
@@ -213,7 +213,7 @@ impl Account {
     /// ```rust,no_run
     /// use binance::{api::*, account::*, config::*};
     /// let account: Account = Binance::new_with_env(&Config::testnet());
-    /// let canceled_orders = tokio_test::block_on(account.cancel_all_open_orders());
+    /// let canceled_orders = tokio_test::block_on(account.cancel_all_open_orders("ETHBTC"));
     /// assert!(canceled_orders.is_ok(), "{:?}", canceled_orders);
     /// ```
     pub async fn cancel_all_open_orders<S>(&self, symbol: S) -> Result<Vec<Order>>

--- a/src/rest_model.rs
+++ b/src/rest_model.rs
@@ -326,7 +326,7 @@ pub enum BookTickers {
     AllBookTickers(Vec<Tickers>),
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 pub enum KlineSummaries {
     AllKlineSummaries(Vec<KlineSummary>),
 }
@@ -1328,7 +1328,8 @@ pub struct InterestRateAssetHistory {
 
 pub type InterestRateHistory = Vec<InterestRateAssetHistory>;
 
-#[derive(Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(rename_all = "camelCase")]
 pub struct KlineSummary {
     pub open_time: i64,
     pub open: f64,


### PR DESCRIPTION
As the title says, added the missing derived Serialize and Deserialize traits to `KlineSummary` and `KlineSummaries` types.

Also fixed a missing argument in a test example that was failing when running `cargo test`.