### PR TITLE
fix: extend the BinanceContentError::code to i32

### DIFF
--- a/examples/binance_endpoints.rs
+++ b/examples/binance_endpoints.rs
@@ -30,7 +30,7 @@ async fn general() {
         Err(err) => {
             match err {
                 BinanceLibError::BinanceError { response } => match response.code {
-                    -1000_i16 => error!("An unknown error occured while processing the request"),
+                    -1000_i32 => error!("An unknown error occured while processing the request"),
                     _ => error!("Non-catched code {}: {}", response.code, response.msg),
                 },
                 _ => error!("Other errors: {}.", err),

--- a/examples/binance_futures.rs
+++ b/examples/binance_futures.rs
@@ -26,7 +26,7 @@ async fn general() {
         Err(err) => {
             match err {
                 BinanceLibError::BinanceError { response } => match response.code {
-                    -1000_i16 => error!("An unknown error occured while processing the request"),
+                    -1000_i32 => error!("An unknown error occured while processing the request"),
                     _ => error!("Uncaught code {}: {}", response.code, response.msg),
                 },
                 BinanceLibError::Msg(msg) => error!("Binancelib error msg: {}", msg),

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -5,7 +5,7 @@ use thiserror::Error;
 #[derive(Debug, Deserialize, Error)]
 #[error("code: {code}, msg: {msg}")]
 pub struct BinanceContentError {
-    pub code: i16,
+    pub code: i32,
     pub msg: String,
 
     #[serde(flatten)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,7 +36,7 @@
 //!         Err(err) => {
 //!             match err {
 //!                 BinanceLibError::BinanceError { response } => match response.code {
-//!                     -1000_i16 => println!("An unknown error occured while processing the request"),
+//!                     -1000_i32 => println!("An unknown error occured while processing the request"),
 //!                     _ => println!("Unknown code {}: {}", response.code, response.msg),
 //!                 },
 //!                 _ => println!("Other errors: {}.", err),


### PR DESCRIPTION
The current error type can't represent the following Binance error:

> code: 51077, msg: Asset precision wrong.

Signed-off-by: MÓZES Ádám István <mozes.adam.istvan@pm.me>