### PR TITLE
Fix margin transfer message encoding

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ ring = "0.16"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 serde_qs = "0.8"
+serde_repr = "0.1.9"
 thiserror = "1.0"
 url = "2.2"
 lazy_static = "1.4"

--- a/src/rest_model.rs
+++ b/src/rest_model.rs
@@ -1,4 +1,5 @@
 use chrono::{DateTime, Utc};
+use serde_repr::{Deserialize_repr, Serialize_repr};
 use std::collections::HashMap;
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -413,7 +414,8 @@ pub struct AggTrade {
     pub qty: f64,
 }
 
-#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
+#[derive(Debug, Serialize_repr, Deserialize_repr, Clone, PartialEq)]
+#[repr(u8)]
 pub enum MarginTransferType {
     FromMainToMargin = 1,
     FromMarginToMain = 2,


### PR DESCRIPTION
This fixes the representation used for this message. It was being converted to a string, not the enum numbers.