### PR TITLE
moved changes from futures branch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ precommit_venv
 *.fmt
 *.iml
 .idea
+.env
 
 release.json
 secrets

--- a/examples/binance_futures.rs
+++ b/examples/binance_futures.rs
@@ -11,6 +11,8 @@ async fn main() {
     general().await;
     #[cfg(feature = "futures_api")]
     market_data().await;
+    #[cfg(feature = "futures_api")]
+    account().await;
 }
 
 #[cfg(feature = "futures_api")]
@@ -109,8 +111,22 @@ async fn market_data() {
         Err(e) => error!("Error: {:?}", e),
     }
 
-    match market.get_funding_rate("BTCUSDT", None, None, None).await {
+    match market.get_funding_rate("BTCUSDT", None, None, 10u16).await {
         Ok(answer) => info!("Funding: {:?}", answer),
+        Err(e) => error!("Error: {:?}", e),
+    }
+}
+
+#[cfg(feature = "futures_api")]
+async fn account() {
+    use binance::{api::Binance, config::Config, futures::account::FuturesAccount};
+    let api_key = Some("".into());
+    let secret_key = Some("".into());
+
+    let account = FuturesAccount::new_with_config(api_key, secret_key, &Config::testnet());
+
+    match account.account_information().await {
+        Ok(answer) => info!("Account Info: {:?}", answer),
         Err(e) => error!("Error: {:?}", e),
     }
 }

--- a/src/futures/market.rs
+++ b/src/futures/market.rs
@@ -1,14 +1,15 @@
-use serde_json::Value;
-
 use crate::client::*;
 use crate::errors::*;
 use crate::futures::rest_model::*;
-use crate::rest_model::{BookTickers, KlineSummaries, KlineSummary, PairAndWindowQuery, PairQuery, SymbolPrice, Tickers};
+use crate::rest_model::{
+    BookTickers, KlineSummaries, KlineSummary, PairAndWindowQuery, PairQuery, SymbolPrice, Tickers,
+};
 use crate::util::*;
+use serde_json::Value;
 
-//TODO: Validate intervals and start/end times in history queries
-//TODO: find out the repartition of kline/candlestick columns in the future kline rows
-//TODO: make limit optional where applicable
+//TODO : Validate intervals and start/end times in history queries
+//TODO : find out the repartition of kline/candlestick columns in the future kline rows
+//TODO : make limit optional where applicable
 
 #[derive(Clone)]
 pub struct FuturesMarket {
@@ -95,27 +96,30 @@ impl FuturesMarket {
     }
 
     /// Get funding rate history
-    pub async fn get_funding_rate<S1, S2, S3, S4>(
+    pub async fn get_funding_rate<S1, S3, S4, S5>(
         &self,
         symbol: S1,
-        start_time: S2,
-        end_time: S3,
-        limit: S4,
+        start_time: S3,
+        end_time: S4,
+        limit: S5,
     ) -> Result<Vec<FundingRate>>
     where
         S1: Into<String>,
-        S2: Into<Option<u64>>,
         S3: Into<Option<u64>>,
-        S4: Into<Option<u16>>,
+        S4: Into<Option<u64>>,
+        S5: Into<u16>,
     {
         self.client
             .get_signed_p(
                 "/fapi/v1/fundingRate",
-                Some(FundingQuery {
-                    symbol: symbol.into(),
+                Some(HistoryQuery {
                     start_time: start_time.into(),
                     end_time: end_time.into(),
                     limit: limit.into(),
+                    symbol: symbol.into(),
+                    from_id: None,
+                    interval: None,
+                    period: None,
                 }),
                 self.recv_window,
             )
@@ -282,7 +286,7 @@ impl FuturesMarket {
     }
 
     /// Returns up to 'limit' klines for given symbol and interval ("1m", "5m", ...)
-    /// <https://github.com/binance-exchange/binance-official-api-docs/blob/master/rest-api.md#klinecandlestick-data>
+    /// https://github.com/binance-exchange/binance-official-api-docs/blob/master/rest-api.md#klinecandlestick-data
     pub async fn get_klines<S1, S2, S3, S4, S5>(
         &self,
         symbol: S1,
@@ -331,7 +335,7 @@ impl FuturesMarket {
 
     /// Returns up to 'limit' blvt klines for given symbol and interval ("1m", "5m", ...)
     /// Note that the symbol is not the traditional pair but rather {symbol}{UP|DOWN}
-    /// <https://binance-docs.github.io/apidocs/futures/en/#blvt-nav-kline-candlestick-streams>
+    /// https://binance-docs.github.io/apidocs/futures/en/#blvt-nav-kline-candlestick-streams
     /// As the vector fields are undocumented on binance futures you are un your own, follow
     /// KlineSummary for an example
     pub async fn get_blvt_klines_v<S1, S2, S3, S4, S5>(
@@ -364,7 +368,7 @@ impl FuturesMarket {
     }
 
     /// Returns up to 'limit' mark price klines for given symbol and interval ("1m", "5m", ...)
-    /// <https://binance-docs.github.io/apidocs/futures/en/#mark-price-kline-candlestick-data>
+    /// https://binance-docs.github.io/apidocs/futures/en/#mark-price-kline-candlestick-data
     /// As the vector fields are undocumented on binance futures you are un your own, follow
     /// KlineSummary for an example
     pub async fn get_mark_price_klines_v<S1, S2, S3, S4, S5>(
@@ -397,7 +401,7 @@ impl FuturesMarket {
     }
 
     /// Returns up to 'limit' index price klines for given symbol and interval ("1m", "5m", ...)
-    /// <https://binance-docs.github.io/apidocs/futures/en/#index-price-kline-candlestick-data>
+    /// https://binance-docs.github.io/apidocs/futures/en/#index-price-kline-candlestick-data
     /// As the vector fields are undocumented on binance futures you are un your own, follow
     /// KlineSummary for an example
     pub async fn get_index_price_klines_v<S1, S2, S3, S4, S5>(
@@ -431,7 +435,7 @@ impl FuturesMarket {
     }
 
     /// Returns up to 'limit' continuous contract klines for given symbol and interval ("1m", "5m", ...)
-    /// <https://binance-docs.github.io/apidocs/futures/en/#continuous-contract-kline-candlestick-data>
+    /// https://binance-docs.github.io/apidocs/futures/en/#continuous-contract-kline-candlestick-data
     /// As the vector fields are undocumented on binance futures you are un your own, follow
     /// KlineSummary for an example
     pub async fn get_continuous_contract_klines_v<S1, S2, S3, S4, S5>(
@@ -463,7 +467,7 @@ impl FuturesMarket {
         Ok(klines)
     }
 
-    /// <https://binance-docs.github.io/apidocs/futures/en/#notional-and-leverage-brackets-user_data>
+    /// https://binance-docs.github.io/apidocs/futures/en/#notional-and-leverage-brackets-user_data
     pub async fn get_notional_leverage_brackets<S>(&self, symbol: S) -> Result<SymbolBrackets>
     where
         S: Into<String>,
@@ -477,7 +481,7 @@ impl FuturesMarket {
             .await
     }
 
-    /// <https://binance-docs.github.io/apidocs/futures/en/#composite-index-symbol-information>
+    /// https://binance-docs.github.io/apidocs/futures/en/#composite-index-symbol-information
     /// Only for composite symbols (ex: DEFIUSDT)
     pub async fn get_index_info<S>(&self, symbol: Option<S>) -> Result<PriceStats>
     where
@@ -528,7 +532,13 @@ impl FuturesMarket {
             .await
     }
 
-    pub async fn get_mark_prices(&self) -> Result<MarkPrices> { self.client.get_p("/fapi/v1/premiumIndex", None).await }
+    pub async fn get_mark_prices(&self) -> Result<MarkPrices> {
+        self.client.get_p("/fapi/v1/premiumIndex", None).await
+    }
+
+    pub async fn get_all_liquidation_orders(&self) -> Result<LiquidationOrders> {
+        self.client.get_p("/fapi/v1/allForceOrders", None).await
+    }
 
     pub async fn open_interest<S>(&self, symbol: S) -> Result<OpenInterest>
     where

--- a/src/futures/mod.rs
+++ b/src/futures/mod.rs
@@ -1,6 +1,3 @@
-/// Futures API modules
-/// # Examples
-/// See examples/binance_futures.rs
 pub mod account;
 pub mod general;
 pub mod market;

--- a/src/futures/rest_model.rs
+++ b/src/futures/rest_model.rs
@@ -48,7 +48,7 @@ pub struct Symbol {
     pub quote_precision: u64,
     pub underlying_type: String,
     pub underlying_sub_type: Vec<String>,
-    pub settle_plan: u16,
+    pub settle_plan: u64,
     #[serde(with = "string_or_float")]
     pub trigger_protect: f64,
     pub filters: Vec<Filters>,

--- a/src/futures/rest_model.rs
+++ b/src/futures/rest_model.rs
@@ -1,7 +1,10 @@
 use serde::{Deserialize, Serialize};
 
-use crate::rest_model::{string_or_float, string_or_float_opt, Asks, Bids, RateLimit, SymbolStatus, TimeInForce};
-pub use crate::rest_model::{BookTickers, KlineSummaries, KlineSummary, ServerTime, SymbolPrice, Tickers};
+use crate::rest_model::{string_or_bool, string_or_float, string_or_float_opt, string_or_u64};
+pub use crate::rest_model::{
+    Asks, Bids, BookTickers, KlineSummaries, KlineSummary, OrderSide, OrderStatus, RateLimit, ServerTime, SymbolPrice,
+    SymbolStatus, Tickers, TimeInForce,
+};
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]
@@ -45,7 +48,7 @@ pub struct Symbol {
     pub quote_precision: u64,
     pub underlying_type: String,
     pub underlying_sub_type: Vec<String>,
-    pub settle_plan: u64,
+    pub settle_plan: u16,
     #[serde(with = "string_or_float")]
     pub trigger_protect: f64,
     pub filters: Vec<Filters>,
@@ -53,7 +56,7 @@ pub struct Symbol {
     pub time_in_force: Vec<TimeInForce>,
 }
 
-#[derive(Debug, Deserialize, Serialize, Clone, PartialEq)]
+#[derive(Debug, Deserialize, Serialize, Clone)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 pub enum ContractType {
     Perpetual,
@@ -63,11 +66,9 @@ pub enum ContractType {
     NextQuarter,
     #[serde(rename = "")]
     Empty,
-    #[serde(other)]
-    Other,
 }
 
-#[derive(Debug, Deserialize, Serialize, Clone, PartialEq)]
+#[derive(Debug, Deserialize, Serialize, Clone)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 pub enum OrderType {
     Limit,
@@ -77,11 +78,38 @@ pub enum OrderType {
     TakeProfit,
     TakeProfitMarket,
     TrailingStopMarket,
-    #[serde(other)]
-    Other,
 }
 
-#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
+/// By default, use market orders
+impl Default for OrderType {
+    fn default() -> Self {
+        Self::Market
+    }
+}
+
+#[derive(Debug, Deserialize, Serialize, Clone)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+pub enum PositionSide {
+    Both,
+    Long,
+    Short,
+}
+
+#[derive(Debug, Deserialize, Serialize, Clone)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+pub enum WorkingType {
+    MarkPrice,
+    ContractPrice,
+}
+
+#[derive(Debug, Deserialize, Serialize, Clone)]
+#[serde(rename_all = "lowercase")]
+pub enum MarginType {
+    Isolated,
+    Cross,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
 #[serde(tag = "filterType")]
 pub enum Filters {
     #[serde(rename = "PRICE_FILTER")]
@@ -107,12 +135,9 @@ pub enum Filters {
     #[serde(rename = "MARKET_LOT_SIZE")]
     #[serde(rename_all = "camelCase")]
     MarketLotSize {
-        #[serde(with = "string_or_float")]
-        min_qty: f64,
-        #[serde(with = "string_or_float")]
-        max_qty: f64,
-        #[serde(with = "string_or_float")]
-        step_size: f64,
+        min_qty: String,
+        max_qty: String,
+        step_size: String,
     },
     #[serde(rename = "MAX_NUM_ORDERS")]
     #[serde(rename_all = "camelCase")]
@@ -182,13 +207,13 @@ pub struct PriceStats {
     pub count: u64,
 }
 
-#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 #[serde(untagged)]
 pub enum Trades {
     AllTrades(Vec<Trade>),
 }
 
-#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct Trade {
     pub id: u64,
@@ -202,13 +227,13 @@ pub struct Trade {
     pub time: u64,
 }
 
-#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 #[serde(untagged)]
 pub enum AggTrades {
     AllAggTrades(Vec<AggTrade>),
 }
 
-#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct AggTrade {
     #[serde(rename = "T")]
@@ -227,13 +252,13 @@ pub struct AggTrade {
     pub qty: f64,
 }
 
-#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 #[serde(untagged)]
 pub enum MarkPrices {
     AllMarkPrices(Vec<MarkPrice>),
 }
 
-#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct MarkPrice {
     pub symbol: String,
@@ -245,13 +270,13 @@ pub struct MarkPrice {
     pub time: u64,
 }
 
-#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 #[serde(untagged)]
 pub enum LiquidationOrders {
     AllLiquidationOrders(Vec<LiquidationOrder>),
 }
 
-#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct LiquidationOrder {
     #[serde(with = "string_or_float")]
@@ -278,43 +303,43 @@ pub struct OpenInterest {
     pub symbol: String,
 }
 
-// #[derive(Debug, Deserialize, Clone)]
-// #[serde(rename_all = "camelCase")]
-// struct Order {
-//     pub client_order_id: String,
-//     #[serde(with = "string_or_float")]
-//     pub cum_qty: f64,
-//     #[serde(with = "string_or_float")]
-//     pub cum_quote: f64,
-//     #[serde(with = "string_or_float")]
-//     pub executed_qty: f64,
-//     pub order_id: u64,
-//     #[serde(with = "string_or_float")]
-//     pub avg_price: f64,
-//     #[serde(with = "string_or_float")]
-//     pub orig_qty: f64,
-//     #[serde(with = "string_or_float")]
-//     pub price: f64,
-//     pub side: String,
-//     pub reduce_only: bool,
-//     pub position_side: String,
-//     pub status: String,
-//     #[serde(with = "string_or_float", default = "default_stop_price")]
-//     pub stop_price: f64,
-//     pub close_position: bool,
-//     pub symbol: String,
-//     pub time_in_force: String,
-//     #[serde(rename = "type")]
-//     pub order_type: String,
-//     pub orig_type: String,
-//     #[serde(with = "string_or_float", default = "default_activation_price")]
-//     pub activation_price: f64,
-//     #[serde(with = "string_or_float", default = "default_price_rate")]
-//     pub price_rate: f64,
-//     pub update_time: u64,
-//     pub working_type: String,
-//     pub price_protect: bool,
-// }
+#[derive(Debug, Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct Order {
+    pub client_order_id: String,
+    #[serde(with = "string_or_float")]
+    pub cum_qty: f64,
+    #[serde(with = "string_or_float")]
+    pub cum_quote: f64,
+    #[serde(with = "string_or_float")]
+    pub executed_qty: f64,
+    pub order_id: u64,
+    #[serde(with = "string_or_float")]
+    pub avg_price: f64,
+    #[serde(with = "string_or_float")]
+    pub orig_qty: f64,
+    #[serde(with = "string_or_float")]
+    pub price: f64,
+    pub side: OrderSide,
+    pub reduce_only: bool,
+    pub position_side: PositionSide,
+    pub status: OrderStatus,
+    #[serde(with = "string_or_float", default = "default_stop_price")]
+    pub stop_price: f64,
+    pub close_position: bool,
+    pub symbol: String,
+    pub time_in_force: TimeInForce,
+    #[serde(rename = "type")]
+    pub order_type: OrderType,
+    pub orig_type: OrderType,
+    #[serde(with = "string_or_float", default = "default_activation_price")]
+    pub activation_price: f64,
+    #[serde(with = "string_or_float", default = "default_price_rate")]
+    pub price_rate: f64,
+    pub update_time: u64,
+    pub working_type: WorkingType,
+    pub price_protect: bool,
+}
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]
@@ -332,23 +357,25 @@ pub struct Transaction {
     #[serde(with = "string_or_float")]
     pub orig_qty: f64,
     pub reduce_only: bool,
-    pub side: String,
-    pub position_side: String,
-    pub status: String,
+    pub side: OrderSide,
+    pub position_side: PositionSide,
+    pub status: OrderStatus,
     #[serde(with = "string_or_float")]
     pub stop_price: f64,
     pub close_position: bool,
     pub symbol: String,
-    pub time_in_force: String,
+    pub time_in_force: TimeInForce,
     #[serde(rename = "type")]
-    pub type_name: String,
-    pub orig_type: String,
-    #[serde(default, with = "string_or_float_opt")]
+    pub type_name: OrderType,
+    pub orig_type: OrderType,
+    #[serde(default)]
+    #[serde(with = "string_or_float_opt")]
     pub activate_price: Option<f64>,
-    #[serde(default, with = "string_or_float_opt")]
+    #[serde(default)]
+    #[serde(with = "string_or_float_opt")]
     pub price_rate: Option<f64>,
     pub update_time: u64,
-    pub working_type: String,
+    pub working_type: WorkingType,
     price_protect: bool,
 }
 
@@ -379,9 +406,11 @@ pub struct CanceledOrder {
     pub time_in_force: String,
     #[serde(rename = "type")]
     pub type_name: String,
-    #[serde(default, with = "string_or_float_opt")]
+    #[serde(default)]
+    #[serde(with = "string_or_float_opt")]
     pub activate_price: Option<f64>,
-    #[serde(default, with = "string_or_float_opt")]
+    #[serde(default)]
+    #[serde(with = "string_or_float_opt")]
     pub price_rate: Option<f64>,
     pub update_time: u64,
     pub working_type: String,
@@ -393,12 +422,12 @@ pub struct CanceledOrder {
 pub struct Position {
     #[serde(with = "string_or_float")]
     pub entry_price: f64,
-    pub margin_type: String,
+    pub margin_type: MarginType,
     #[serde(with = "string_or_bool")]
     pub is_auto_add_margin: bool,
     #[serde(with = "string_or_float")]
     pub isolated_margin: f64,
-    pub leverage: String,
+    pub leverage: u64,
     #[serde(with = "string_or_float")]
     pub liquidation_price: f64,
     #[serde(with = "string_or_float")]
@@ -410,7 +439,110 @@ pub struct Position {
     pub symbol: String,
     #[serde(with = "string_or_float", rename = "unRealizedProfit")]
     pub unrealized_profit: f64,
-    pub position_side: String,
+    pub position_side: PositionSide,
+    pub update_time: u64,
+    #[serde(with = "string_or_float")]
+    pub notional: f64,
+    #[serde(with = "string_or_float")]
+    pub isolated_wallet: f64,
+}
+
+// https://binance-docs.github.io/apidocs/futures/en/#account-information-v2-user_data
+// it has differences from Position returned by positionRisk endpoint
+#[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct AccountPosition {
+    pub symbol: String,
+    #[serde(with = "string_or_float")]
+    pub initial_margin: f64,
+    #[serde(with = "string_or_float", rename = "maintMargin")]
+    pub maintenance_margin: f64,
+    #[serde(with = "string_or_float")]
+    pub unrealized_profit: f64,
+    #[serde(with = "string_or_float")]
+    pub position_initial_margin: f64,
+    #[serde(with = "string_or_float")]
+    pub open_order_initial_margin: f64,
+    #[serde(with = "string_or_u64")]
+    pub leverage: u64,
+    pub isolated: bool,
+    #[serde(with = "string_or_float")]
+    pub entry_price: f64,
+    #[serde(with = "string_or_float")]
+    pub max_notional: f64,
+    #[serde(with = "string_or_float")]
+    pub bid_notional: f64,
+    #[serde(with = "string_or_float")]
+    pub ask_notional: f64,
+    pub position_side: PositionSide,
+    #[serde(with = "string_or_float", rename = "positionAmt")]
+    pub position_amount: f64,
+    pub update_time: u64,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct AccountAsset {
+    pub asset: String,
+    #[serde(with = "string_or_float")]
+    pub wallet_balance: f64,
+    #[serde(with = "string_or_float")]
+    pub unrealized_profit: f64,
+    #[serde(with = "string_or_float")]
+    pub margin_balance: f64,
+    #[serde(with = "string_or_float")]
+    pub maint_margin: f64,
+    #[serde(with = "string_or_float")]
+    pub initial_margin: f64,
+    #[serde(with = "string_or_float")]
+    pub position_initial_margin: f64,
+    #[serde(with = "string_or_float")]
+    pub open_order_initial_margin: f64,
+    #[serde(with = "string_or_float")]
+    pub cross_wallet_balance: f64,
+    #[serde(with = "string_or_float", rename = "crossUnPnl")]
+    pub cross_unrealized_pnl: f64,
+    #[serde(with = "string_or_float")]
+    pub available_balance: f64,
+    #[serde(with = "string_or_float")]
+    pub max_withdraw_amount: f64,
+    pub margin_available: bool,
+    pub update_time: u64,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct AccountInformation {
+    pub fee_tier: u64,
+    pub can_trade: bool,
+    pub can_deposit: bool,
+    pub can_withdraw: bool,
+    pub update_time: u64,
+    pub multi_assets_margin: bool,
+    #[serde(with = "string_or_float")]
+    pub total_initial_margin: f64,
+    #[serde(with = "string_or_float", rename = "totalMaintMargin")]
+    pub total_maintenance_margin: f64,
+    #[serde(with = "string_or_float")]
+    pub total_wallet_balance: f64,
+    #[serde(with = "string_or_float")]
+    pub total_unrealized_profit: f64,
+    #[serde(with = "string_or_float")]
+    pub total_margin_balance: f64,
+    #[serde(with = "string_or_float")]
+    pub total_position_initial_margin: f64,
+    #[serde(with = "string_or_float")]
+    pub total_open_order_initial_margin: f64,
+    #[serde(with = "string_or_float")]
+    pub total_cross_wallet_balance: f64,
+    #[serde(with = "string_or_float", rename = "totalCrossUnPnl")]
+    pub total_cross_unrealized_pnl: f64,
+    #[serde(with = "string_or_float")]
+    pub available_balance: f64,
+    #[serde(with = "string_or_float")]
+    pub max_withdraw_amount: f64,
+    pub assets: Vec<AccountAsset>,
+    pub positions: Vec<AccountPosition>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -441,6 +573,16 @@ pub struct ChangeLeverageResponse {
     pub symbol: String,
 }
 
+fn default_stop_price() -> f64 {
+    0.0
+}
+fn default_activation_price() -> f64 {
+    0.0
+}
+fn default_price_rate() -> f64 {
+    0.0
+}
+
 #[derive(Serialize)]
 #[serde(rename_all = "camelCase")]
 pub(crate) struct HistoryQuery {
@@ -455,7 +597,7 @@ pub(crate) struct HistoryQuery {
 
 impl HistoryQuery {
     pub fn validate(&self) -> crate::errors::Result<()> {
-        if let Some(period) = self.period.as_ref() {
+        if let Some(period) = &self.period {
             if !PERIODS.contains(&period.as_str()) {
                 return Err(crate::errors::Error::InvalidPeriod(period.clone()));
             }
@@ -464,16 +606,7 @@ impl HistoryQuery {
     }
 }
 
-#[derive(Serialize)]
-#[serde(rename_all = "camelCase")]
-pub(crate) struct FundingQuery {
-    pub symbol: String,
-    pub start_time: Option<u64>,
-    pub end_time: Option<u64>,
-    pub limit: Option<u16>,
-}
-
-#[derive(Debug, Deserialize)]
+#[derive(Deserialize, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct FundingRate {
     pub symbol: String,
@@ -482,7 +615,7 @@ pub struct FundingRate {
     pub funding_rate: f64,
 }
 
-pub static PERIODS: &[&str] = &["5m", "15m", "30m", "1h", "2h", "4h", "6h", "12h", "1d"];
+pub static PERIODS: &'static [&str] = &["5m", "15m", "30m", "1h", "2h", "4h", "6h", "12h", "1d"];
 
 #[derive(Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -524,35 +657,4 @@ pub struct LeverageBracket {
 pub struct SymbolBrackets {
     pub symbol: String,
     pub brackets: Vec<LeverageBracket>,
-}
-
-pub(crate) mod string_or_bool {
-    use std::fmt;
-
-    use serde::{de, Deserialize, Deserializer, Serializer};
-
-    pub fn serialize<T, S>(value: &T, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        T: fmt::Display,
-        S: Serializer,
-    {
-        serializer.collect_str(value)
-    }
-
-    pub fn deserialize<'de, D>(deserializer: D) -> Result<bool, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        #[derive(Deserialize)]
-        #[serde(untagged)]
-        enum StringOrFloat {
-            String(String),
-            Bool(bool),
-        }
-
-        match StringOrFloat::deserialize(deserializer)? {
-            StringOrFloat::String(s) => s.parse().map_err(de::Error::custom),
-            StringOrFloat::Bool(i) => Ok(i),
-        }
-    }
 }

--- a/src/futures/rest_model.rs
+++ b/src/futures/rest_model.rs
@@ -308,8 +308,6 @@ pub struct OpenInterest {
 pub struct Order {
     pub client_order_id: String,
     #[serde(with = "string_or_float")]
-    pub cum_qty: f64,
-    #[serde(with = "string_or_float")]
     pub cum_quote: f64,
     #[serde(with = "string_or_float")]
     pub executed_qty: f64,
@@ -333,7 +331,7 @@ pub struct Order {
     pub order_type: OrderType,
     pub orig_type: OrderType,
     #[serde(with = "string_or_float", default = "default_activation_price")]
-    pub activation_price: f64,
+    pub activate_price: f64,
     #[serde(with = "string_or_float", default = "default_price_rate")]
     pub price_rate: f64,
     pub update_time: u64,

--- a/src/rest_model.rs
+++ b/src/rest_model.rs
@@ -509,7 +509,9 @@ pub enum OrderSide {
 
 /// By default, buy
 impl Default for OrderSide {
-    fn default() -> Self { Self::Buy }
+    fn default() -> Self {
+        Self::Buy
+    }
 }
 
 /// The allowed values are:
@@ -524,7 +526,9 @@ pub enum CancelReplaceMode {
 
 /// By default, STOP_ON_FAILURE
 impl Default for CancelReplaceMode {
-    fn default() -> Self { Self::StopOnFailure }
+    fn default() -> Self {
+        Self::StopOnFailure
+    }
 }
 
 /// Order types, the following restrictions apply
@@ -551,7 +555,9 @@ pub enum OrderType {
 
 /// By default, use market orders
 impl Default for OrderType {
-    fn default() -> Self { Self::Market }
+    fn default() -> Self {
+        Self::Market
+    }
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -2003,6 +2009,68 @@ pub(crate) mod string_or_float_opt {
         }
 
         Ok(Some(crate::rest_model::string_or_float::deserialize(deserializer)?))
+    }
+}
+
+pub mod string_or_u64 {
+    use std::fmt;
+
+    use serde::{de, Deserialize, Deserializer, Serializer};
+
+    pub fn serialize<T, S>(value: &T, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        T: fmt::Display,
+        S: Serializer,
+    {
+        serializer.collect_str(value)
+    }
+
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<u64, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        #[serde(untagged)]
+        enum StringOrU64 {
+            String(String),
+            U64(u64),
+        }
+
+        match StringOrU64::deserialize(deserializer)? {
+            StringOrU64::String(s) => s.parse().map_err(de::Error::custom),
+            StringOrU64::U64(i) => Ok(i),
+        }
+    }
+}
+
+pub(crate) mod string_or_bool {
+    use std::fmt;
+
+    use serde::{de, Deserialize, Deserializer, Serializer};
+
+    pub fn serialize<T, S>(value: &T, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        T: fmt::Display,
+        S: Serializer,
+    {
+        serializer.collect_str(value)
+    }
+
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<bool, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        #[serde(untagged)]
+        enum StringOrFloat {
+            String(String),
+            Bool(bool),
+        }
+
+        match StringOrFloat::deserialize(deserializer)? {
+            StringOrFloat::String(s) => s.parse().map_err(de::Error::custom),
+            StringOrFloat::Bool(i) => Ok(i),
+        }
     }
 }
 


### PR DESCRIPTION
I noticed, that code in master branch and futures branch are quite different, in fact master branch has much newer recent changes, so I remade code from that [pull request](https://github.com/Igosuki/binance-rs-async/pull/76)

I have added new function for futures/account get_open_orders.
Also fixed some types in structures. And changed names of some structure fields/functions to be uniform with api for spot trading.

fixed Position structure to comply with [official api documentation](https://binance-docs.github.io/apidocs/futures/en/#position-information-v2-user_data)

added account_information for [account](https://binance-docs.github.io/apidocs/futures/en/#futures-account-balance-v2-user_data) endpoint