### PR TITLE
Change order_id to String for MarginOrderCancellation

### DIFF
--- a/src/margin.rs
+++ b/src/margin.rs
@@ -275,7 +275,7 @@ impl Margin {
     /// let result = tokio_test::block_on(margin.cancel_trade("BTCUSDT", 1_u64, "my_id".to_string(), "my_next_id".to_string(), None));
     /// assert!(result.is_ok(), "{:?}", result);
     /// ```
-    pub async fn cancel_trade<S, F>(
+    pub async fn cancel_trade<S>(
         &self,
         symbol: S,
         order_id: S,

--- a/src/margin.rs
+++ b/src/margin.rs
@@ -278,14 +278,13 @@ impl Margin {
     pub async fn cancel_trade<S, F>(
         &self,
         symbol: S,
-        order_id: F,
+        order_id: S,
         orig_client_order_id: String,
         new_client_order_id: String,
         is_isolated: Option<bool>,
     ) -> Result<MarginOrderCancellationResult>
     where
         S: Into<String>,
-        F: Into<u64>,
     {
         let margin_order_cancellation: MarginOrderCancellation = MarginOrderCancellation {
             symbol: symbol.into(),

--- a/src/rest_model.rs
+++ b/src/rest_model.rs
@@ -745,7 +745,7 @@ pub struct MarginOrdersQuery {
     pub symbol: String,
     /// "TRUE" or "FALSE", default is "FALSE"
     pub is_isolated: Option<String>,
-    pub order_id: u64,
+    pub order_id: String,
     pub start_time: Option<u64>,
     pub end_time: Option<u64>,
     pub limit: Option<u8>,

--- a/src/rest_model.rs
+++ b/src/rest_model.rs
@@ -589,7 +589,7 @@ pub struct MarginOrder {
 #[serde(rename_all = "camelCase")]
 pub struct MarginOrderCancellation {
     pub symbol: String,
-    pub order_id: u64,
+    pub order_id: String,
     pub orig_client_order_id: String,
     pub new_client_order_id: String,
     pub is_isolated: Option<String>,
@@ -599,7 +599,7 @@ pub struct MarginOrderCancellation {
 #[serde(rename_all = "camelCase")]
 pub struct MarginOrderCancellationResult {
     pub symbol: String,
-    pub order_id: Option<u64>,
+    pub order_id: Option<String>,
     pub orig_client_order_id: Option<String>,
     pub client_order_id: Option<String>,
     #[serde(with = "string_or_float_opt")]

--- a/src/rest_model.rs
+++ b/src/rest_model.rs
@@ -1102,7 +1102,7 @@ pub struct MarginOrderQuery {
 #[serde(rename_all = "camelCase")]
 pub struct MarginOrderResult {
     pub symbol: String,
-    pub order_id: u64,
+    pub order_id: String,
     pub client_order_id: String,
     pub transact_time: u128,
     #[serde(with = "string_or_float")]
@@ -1136,7 +1136,7 @@ pub struct MarginOrderState {
     #[serde(with = "string_or_float")]
     pub iceberg_qty: f64,
     pub is_working: bool,
-    pub order_id: u64,
+    pub order_id: String,
     #[serde(with = "string_or_float")]
     pub orig_qty: f64,
     #[serde(with = "string_or_float")]


### PR DESCRIPTION
Change order_id to String for `MarginOrderCancellation` and `MarginOrderCacellationResult` because the API returns a String. 

When cancelling a Margin order the API will return:

`error decoding response body: invalid type: string "xxxxxxxxxx", expected u64 at line 1 column 23`

Effectively, this is because the `MarginOrderCancellation` and `MarginOrderCancellationResult` structs have their order_id set to a u64 instead of a string when the API returns a string. It could also be possible to parse the String into a u64 because the default order ID is always a valid u64. However, users can pass a custom order_id into an order that can't be parsed into a u64 which suggests that this value should really be a String. Do what you will with this, but I'll be using this version of [binance-rs-async](https://github.com/Igosuki/binance-rs-async) until this is fixed.