### PR TITLE
Mark price stream

### DIFF
--- a/src/websockets.rs
+++ b/src/websockets.rs
@@ -22,6 +22,7 @@ pub static AGGREGATED_TRADE: &str = "aggTrade";
 pub static DEPTH_ORDERBOOK: &str = "depthUpdate";
 pub static PARTIAL_ORDERBOOK: &str = "lastUpdateId";
 pub static DAYTICKER: &str = "24hrTicker";
+pub static MARK_PRICE: &str = "markPrice";
 
 pub fn all_ticker_stream() -> &'static str { "!ticker@arr" }
 
@@ -40,6 +41,12 @@ pub fn all_book_ticker_stream() -> &'static str { "!bookTicker" }
 pub fn all_mini_ticker_stream() -> &'static str { "!miniTicker@arr" }
 
 pub fn mini_ticker_stream(symbol: &str) -> String { format!("{symbol}@miniTicker") }
+
+/// # Arguments
+/// 
+/// * `symbol`: the market symbol
+/// * `update_speed`: 1 or 3
+pub fn mark_price_stream(symbol: &str, update_speed: u8) -> String { format!("{symbol}@markPrice@{update_speed}s") }
 
 /// # Arguments
 ///

--- a/src/websockets.rs
+++ b/src/websockets.rs
@@ -116,6 +116,14 @@ impl<'a, WE: serde::de::DeserializeOwned> WebSockets<'a, WE> {
         self.handle_connect(url).await
     }
 
+    /// Connect to a futures websocket endpoint
+    pub async fn connect_futures(&mut self, endpoint: &str) -> Result<()> {
+        let wss: String = format!("{}/{}/{}", self.conf.futures_ws_endpoint, WS_ENDPOINT, endpoint);
+        let url = Url::parse(&wss)?;
+
+        self.handle_connect(url).await
+    }
+
     async fn handle_connect(&mut self, url: Url) -> Result<()> {
         match connect_async(url).await {
             Ok(answer) => {

--- a/src/ws_model.rs
+++ b/src/ws_model.rs
@@ -23,6 +23,8 @@ pub enum WebsocketEvent {
     OrderUpdate(Box<OrderUpdate>),
     #[serde(alias = "listStatus")]
     ListOrderUpdate(Box<OrderListUpdate>),
+    #[serde(alias = "markPriceUpdate")]
+    MarkPriceUpdate(Box<MarkPriceEvent>),
 }
 
 #[derive(Serialize, Deserialize, Debug)]
@@ -264,6 +266,31 @@ pub struct BookTickerEvent {
 
     #[serde(rename = "A", with = "string_or_float")]
     pub best_ask_qty: f64,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct MarkPriceEvent {
+    #[serde(rename = "E")]
+    pub event_time: u64,
+
+    #[serde(rename = "s")]
+    pub symbol: String,
+
+    #[serde(rename = "p")]
+    pub mark_price: String,
+
+    #[serde(rename = "i")]
+    pub index_price: String,
+
+    #[serde(rename = "P")]
+    pub estimated_settle_price: String,
+
+    #[serde(rename = "r")]
+    pub funding_rate: String,
+
+    #[serde(rename = "T")]
+    pub next_funding_time: u64,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]


### PR DESCRIPTION
Add websockets support for mark price stream: (https://binance-docs.github.io/apidocs/futures/en/#aggregate-trade-streams).