### PR TITLE
Fix contract types for get_exchange_info()

### DIFF
--- a/src/futures/rest_model.rs
+++ b/src/futures/rest_model.rs
@@ -64,6 +64,8 @@ pub enum ContractType {
     NextMonth,
     CurrentQuarter,
     NextQuarter,
+    #[serde(rename = "CURRENT_QUARTER DELIVERING")]
+    CurrentQuarterDelivery,
     #[serde(rename = "")]
     Empty,
 }
@@ -82,9 +84,7 @@ pub enum OrderType {
 
 /// By default, use market orders
 impl Default for OrderType {
-    fn default() -> Self {
-        Self::Market
-    }
+    fn default() -> Self { Self::Market }
 }
 
 #[derive(Debug, Deserialize, Serialize, Clone)]


### PR DESCRIPTION
Issue:
- https://github.com/Igosuki/binance-rs-async/issues/108
- Basically, the contract types do not map with the current struct working after Binance updated their api, leading to errors


Changes:
- Added type for deserialisation of `CURRENT_QUARTER DELIVERING`