### PR TITLE
Futures API Enhancements

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -27,7 +27,7 @@ impl Config {
             .set_rest_api_endpoint("https://testnet.binance.vision")
             .set_ws_endpoint("wss://testnet.binance.vision")
             .set_futures_rest_api_endpoint("https://testnet.binancefuture.com")
-            .set_futures_ws_endpoint("wss://stream.binancefuture.com")
+            .set_futures_ws_endpoint("wss://fstream.binancefuture.com")
     }
 
     /// Sets the rest api endpoint. Defaults to <https://api.binance.com>.

--- a/src/config.rs
+++ b/src/config.rs
@@ -27,7 +27,7 @@ impl Config {
             .set_rest_api_endpoint("https://testnet.binance.vision")
             .set_ws_endpoint("wss://testnet.binance.vision")
             .set_futures_rest_api_endpoint("https://testnet.binancefuture.com")
-            .set_futures_ws_endpoint("wss://testnet.binancefuture.com")
+            .set_futures_ws_endpoint("wss://stream.binancefuture.com")
     }
 
     /// Sets the rest api endpoint. Defaults to <https://api.binance.com>.

--- a/src/futures/market.rs
+++ b/src/futures/market.rs
@@ -508,7 +508,7 @@ impl FuturesMarket {
         S: Into<String>,
     {
         self.client
-            .get_d("/fapi/v1/ticker/price", Some(PairQuery { symbol: symbol.into() }))
+            .get_d("/fapi/v2/ticker/price", Some(PairQuery { symbol: symbol.into() }))
             .await
     }
 

--- a/src/futures/mod.rs
+++ b/src/futures/mod.rs
@@ -4,3 +4,4 @@ pub mod market;
 pub mod rest_model;
 pub mod userstream;
 pub mod websockets;
+pub mod ws_model;

--- a/src/futures/websockets.rs
+++ b/src/futures/websockets.rs
@@ -58,17 +58,17 @@ pub fn diff_book_depth_stream(symbol: &str, update_speed: u16) -> String { forma
 
 fn combined_stream(streams: Vec<String>) -> String { streams.join("/") }
 
-pub struct FuturesWebSockets<'a, WE> {
+pub struct WebSockets<'a, WE> {
     pub socket: Option<(WebSocketStream<MaybeTlsStream<TcpStream>>, Response)>,
     handler: Box<dyn FnMut(WE) -> Result<()> + 'a + Send>,
     conf: Config,
 }
 
-impl<'a, WE: serde::de::DeserializeOwned> FuturesWebSockets<'a, WE> {
+impl<'a, WE: serde::de::DeserializeOwned> WebSockets<'a, WE> {
     /// New websocket holder with default configuration
     /// # Examples
     /// see examples/binance_websockets.rs
-    pub fn new<Callback>(handler: Callback) -> FuturesWebSockets<'a, WE>
+    pub fn new<Callback>(handler: Callback) -> WebSockets<'a, WE>
     where
         Callback: FnMut(WE) -> Result<()> + 'a + Send,
     {
@@ -78,11 +78,11 @@ impl<'a, WE: serde::de::DeserializeOwned> FuturesWebSockets<'a, WE> {
     /// New websocket holder with provided configuration
     /// # Examples
     /// see examples/binance_websockets.rs
-    pub fn new_with_options<Callback>(handler: Callback, conf: Config) -> FuturesWebSockets<'a, WE>
+    pub fn new_with_options<Callback>(handler: Callback, conf: Config) -> WebSockets<'a, WE>
     where
         Callback: FnMut(WE) -> Result<()> + 'a + Send,
     {
-        FuturesWebSockets {
+        WebSockets {
             socket: None,
             handler: Box::new(handler),
             conf,

--- a/src/futures/ws_model.rs
+++ b/src/futures/ws_model.rs
@@ -1,5 +1,5 @@
 use crate::futures::rest_model::{MarginType, OrderType, PositionSide, WorkingType};
-use crate::rest_model::{string_or_float, string_or_float_opt, OrderSide, OrderStatus, TimeInForce};
+use crate::rest_model::{string_or_float, string_or_float_opt, ExecutionType, OrderSide, OrderStatus, TimeInForce};
 
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE", tag = "e")]
@@ -164,25 +164,6 @@ pub struct Order {
     pub price_match: PriceMatch,
     #[serde(rename = "gtd")]
     pub good_till_date: u64
-}
-
-#[derive(Debug, Deserialize)]
-#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
-pub enum ExecutionType {
-    /// The order has been accepted into the engine.
-    New,
-    /// The order has been canceled by the user.
-    Canceled,
-    /// (currently unused)
-    Replaced,
-    /// The order has been rejected and was not processed (This message appears only with Cancel Replace Orders wherein the new order placement is rejected but the request to cancel request succeeds.)
-    Rejected,
-    /// Part of the order or all of the order's quantity has filled.
-    Trade,
-    /// The order was canceled according to the order type's rules (e.g. LIMIT FOK orders with no fill, LIMIT IOC or MARKET orders that partially fill) or by the exchange, (e.g. orders canceled during liquidation, orders canceled during maintenance).
-    Expired,
-    /// The order has expired due to STP trigger.
-    TradePrevention,
 }
 
 #[derive(Debug, Deserialize)]

--- a/src/futures/ws_model.rs
+++ b/src/futures/ws_model.rs
@@ -84,7 +84,7 @@ pub struct Position {
     pub position_side: PositionSide,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Clone, Debug, Deserialize)]
 pub struct OrderTradeUpdate {
     #[serde(rename = "E")]
     pub event_time: u64,
@@ -94,7 +94,7 @@ pub struct OrderTradeUpdate {
     pub order: Order,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Clone, Debug, Deserialize)]
 pub struct Order {
     #[serde(rename = "s")]
     pub symbol: String,
@@ -166,7 +166,7 @@ pub struct Order {
     pub good_till_date: u64
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Clone, Debug, Deserialize)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 pub enum PriceMatch {
     /// No price match
@@ -189,7 +189,7 @@ pub enum PriceMatch {
     Queue20,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Clone, Debug, Deserialize)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 pub enum SelfTradePreventionMode {
     /// No Self-Trade Prevention

--- a/src/futures/ws_model.rs
+++ b/src/futures/ws_model.rs
@@ -1,0 +1,222 @@
+use crate::futures::rest_model::{MarginType, OrderType, PositionSide, WorkingType};
+use crate::rest_model::{string_or_float, string_or_float_opt, OrderSide, OrderStatus, TimeInForce};
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE", tag = "e")]
+pub enum WebsocketEvent {
+    AccountUpdate(Box<AccountUpdate>),
+    OrderTradeUpdate(Box<OrderTradeUpdate>),
+}
+
+#[derive(Debug, Deserialize)]
+pub struct AccountUpdate {
+    #[serde(rename = "E")]
+    pub event_time: u64,
+    #[serde(rename = "T")]
+    pub transaction_time: u64,
+    #[serde(rename = "a")]
+    pub account: Account,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct Account {
+    #[serde(rename = "m")]
+    pub reason_type: ReasonType,
+    #[serde(rename = "B")]
+    pub balances: Vec<Balance>,
+    #[serde(rename = "P")]
+    pub positions: Vec<Position>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+pub enum ReasonType {
+    Deposit,
+    Withdraw,
+    Order,
+    FundingFee,
+    WithdrawReject,
+    Adjustment,
+    InsuranceClear,
+    AdminDeposit,
+    AdminWithdraw,
+    MarginTransfer,
+    MarginTypeChange,
+    AssetTransfer,
+    OptionsPremiumFee,
+    OptionsSettleProfit,
+    AutoExchange,
+    CoinSwapDeposit,
+    CoinSwapWithdraw,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct Balance {
+    #[serde(rename = "a")]
+    pub asset: String,
+    #[serde(rename = "wb", with = "string_or_float")]
+    pub wallet_balance: f64,
+    #[serde(rename = "cw", with = "string_or_float")]
+    pub cross_wallet_balance: f64,
+    #[serde(rename = "bc", with = "string_or_float")]
+    pub balance_change: f64,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct Position {
+    #[serde(rename = "s")]
+    pub symbol: String,
+    #[serde(rename = "pa", with = "string_or_float")]
+    pub position_amount: f64,
+    #[serde(rename = "ep", with = "string_or_float")]
+    pub entry_price: f64,
+    #[serde(rename = "bep", with = "string_or_float")]
+    pub breakeven_price: f64,
+    #[serde(rename = "cr", with = "string_or_float")]
+    pub accumulated_realized: f64,
+    #[serde(rename = "up", with = "string_or_float")]
+    pub unrealized_profit: f64,
+    #[serde(rename = "mt")]
+    pub margin_type: MarginType,
+    #[serde(rename = "iw", with = "string_or_float")]
+    pub isolated_wallet: f64,
+    #[serde(rename = "ps")]
+    pub position_side: PositionSide,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct OrderTradeUpdate {
+    #[serde(rename = "E")]
+    pub event_time: u64,
+    #[serde(rename = "T")]
+    pub transaction_time: u64,
+    #[serde(rename = "o")]
+    pub order: Order,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct Order {
+    #[serde(rename = "s")]
+    pub symbol: String,
+    #[serde(rename = "c")]
+    pub client_order_id: String,
+    #[serde(rename = "S")]
+    pub side: OrderSide,
+    #[serde(rename = "o")]
+    pub order_type: OrderType,
+    #[serde(rename = "f")]
+    pub time_in_force: TimeInForce,
+    #[serde(rename = "q", with = "string_or_float")]
+    pub quantity: f64,
+    #[serde(rename = "p", with = "string_or_float")]
+    pub price: f64,
+    #[serde(rename = "ap", with = "string_or_float")]
+    pub average_price: f64,
+    #[serde(rename = "sp", with = "string_or_float")]
+    pub stop_price: f64,
+    #[serde(rename = "x")]
+    pub execution_type: ExecutionType,
+    #[serde(rename = "X")]
+    pub order_status: OrderStatus,
+    #[serde(rename = "i")]
+    pub order_id: u64,
+    #[serde(rename = "l", with = "string_or_float")]
+    pub order_last_filled_quantity: f64,
+    #[serde(rename = "z", with = "string_or_float")]
+    pub order_filled_accumulated_quantity: f64,
+    #[serde(rename = "L", with = "string_or_float")]
+    pub last_filled_price: f64,
+    #[serde(default, rename = "n", with = "string_or_float_opt")]
+    pub commission: Option<f64>,
+    #[serde(rename = "N")]
+    pub commission_asset: Option<String>,
+    #[serde(rename = "T")]
+    pub order_trade_time: u64,
+    #[serde(rename = "t")]
+    pub trade_id: u64,
+    #[serde(rename = "b", with = "string_or_float")]
+    pub bid_notional: f64,
+    #[serde(rename = "a", with = "string_or_float")]
+    pub ask_notional: f64,
+    #[serde(rename = "m")]
+    pub is_maker: bool,
+    #[serde(rename = "R")]
+    pub is_reduce: bool,
+    #[serde(rename = "wt")]
+    pub working_type: WorkingType,
+    #[serde(rename = "ot")]
+    pub original_order_type: OrderType,
+    #[serde(rename = "ps")]
+    pub position_side: PositionSide,
+    #[serde(rename = "cp")]
+    pub close_position: bool,
+    #[serde(default, rename = "AP", with = "string_or_float_opt")]
+    pub activation_price: Option<f64>,
+    #[serde(default, rename = "cr", with = "string_or_float_opt")]
+    pub callback_rate: Option<f64>,
+    #[serde(rename = "pP")]
+    pub price_protect: bool,
+    #[serde(rename = "rp", with = "string_or_float")]
+    pub realized_profit: f64,
+    #[serde(rename = "V")]
+    pub stp_mode: SelfTradePreventionMode,
+    #[serde(rename = "pm")]
+    pub price_match: PriceMatch,
+    #[serde(rename = "gtd")]
+    pub good_till_date: u64
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+pub enum ExecutionType {
+    /// The order has been accepted into the engine.
+    New,
+    /// The order has been canceled by the user.
+    Canceled,
+    /// (currently unused)
+    Replaced,
+    /// The order has been rejected and was not processed (This message appears only with Cancel Replace Orders wherein the new order placement is rejected but the request to cancel request succeeds.)
+    Rejected,
+    /// Part of the order or all of the order's quantity has filled.
+    Trade,
+    /// The order was canceled according to the order type's rules (e.g. LIMIT FOK orders with no fill, LIMIT IOC or MARKET orders that partially fill) or by the exchange, (e.g. orders canceled during liquidation, orders canceled during maintenance).
+    Expired,
+    /// The order has expired due to STP trigger.
+    TradePrevention,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+pub enum PriceMatch {
+    /// No price match
+    None,
+    /// Counterparty best price
+    Opponent,
+    /// The 5th best price from the counterparty
+    Opponent5,
+    /// The 10th best price from the counterparty
+    Opponent10,
+    /// The 20th best price from the counterparty
+    Opponent20,
+    /// The best price on the same side of the order book
+    Queue,
+    /// The 5th best price on the same side of the order book
+    Queue5,
+    /// The 10th best price on the same side of the order book
+    Queue10,
+    /// The 20th best price on the same side of the order book
+    Queue20,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+pub enum SelfTradePreventionMode {
+    /// No Self-Trade Prevention
+    None,
+    /// Expire taker order when STP trigger
+    ExpireTaker,
+    /// Expire taker and maker order when STP trigger
+    ExpireBoth,
+    /// Expire maker order when STP trigger
+    ExpireMaker,
+}

--- a/src/rest_model.rs
+++ b/src/rest_model.rs
@@ -1221,6 +1221,25 @@ pub enum SymbolPermission {
     Other,
 }
 
+#[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+pub enum ExecutionType {
+    /// The order has been accepted into the engine.
+    New,
+    /// The order has been canceled by the user.
+    Canceled,
+    /// Currently unused
+    Replaced,
+    /// The order has been rejected and was not processed (This message appears only with Cancel Replace Orders wherein the new order placement is rejected but the request to cancel request succeeds.)
+    Rejected,
+    /// Part of the order or all of the order's quantity has filled.
+    Trade,
+    /// The order was canceled according to the order type's rules (e.g. LIMIT FOK orders with no fill, LIMIT IOC or MARKET orders that partially fill) or by the exchange, (e.g. orders canceled during liquidation, orders canceled during maintenance).
+    Expired,
+    /// The order has expired due to STP trigger.
+    TradePrevention,
+}
+
 /// Status of an order, this can typically change over time
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]

--- a/src/rest_model.rs
+++ b/src/rest_model.rs
@@ -1233,14 +1233,14 @@ pub enum OrderStatus {
     Filled,
     /// The order has been canceled by the user.
     Canceled,
-    /// (currently unused)
+    /// Currently unused
     PendingCancel,
     /// The order was not accepted by the engine and not processed.
     Rejected,
     /// The order was canceled according to the order type's rules (e.g. LIMIT FOK orders with no fill, LIMIT IOC or MARKET orders that partially fill) or by the exchange, (e.g. orders canceled during liquidation, orders canceled during maintenance)
     Expired,
-    /// Part of the order or all of the order's quantity has filled.
-    Trade,
+    /// The order was canceled by the exchange due to STP trigger. (e.g. an order with EXPIRE_TAKER will match with existing orders on the book with the same account or same tradeGroupId)
+    ExpiredInMatch,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
@@ -1993,7 +1993,7 @@ pub mod string_or_float {
 pub(crate) mod string_or_float_opt {
     use std::fmt;
 
-    use serde::{Deserialize, Deserializer, Serializer};
+    use serde::{Deserializer, Serializer};
 
     pub fn serialize<T, S>(value: &Option<T>, serializer: S) -> Result<S::Ok, S::Error>
     where
@@ -2010,13 +2010,6 @@ pub(crate) mod string_or_float_opt {
     where
         D: Deserializer<'de>,
     {
-        #[derive(Deserialize)]
-        #[serde(untagged)]
-        enum StringOrFloat {
-            String(String),
-            Float(f64),
-        }
-
         Ok(Some(crate::rest_model::string_or_float::deserialize(deserializer)?))
     }
 }

--- a/src/ws_model.rs
+++ b/src/ws_model.rs
@@ -1,4 +1,4 @@
-use crate::rest_model::{string_or_float, Asks, Bids, OrderBook, OrderSide, OrderStatus, OrderType, TimeInForce};
+use crate::rest_model::{string_or_float, Asks, Bids, ExecutionType, OrderBook, OrderSide, OrderStatus, OrderType, TimeInForce};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(tag = "e")]
@@ -428,7 +428,7 @@ pub struct OrderUpdate {
     #[serde(rename = "C")]
     pub origin_client_id: Option<String>,
     #[serde(rename = "x")]
-    pub execution_type: OrderStatus,
+    pub execution_type: ExecutionType,
     #[serde(rename = "X")]
     pub current_order_status: OrderStatus,
     #[serde(rename = "r")]


### PR DESCRIPTION
Use the correct Binance Futures Testnet WebSocket endpoint.
Update OrderStatus enum and remove redundant StringOrFloat.
Add ws_model module for Futures API WebSocket events.
Rename FuturesWebSockets to WebSockets to be consistent with UserStream.
Move ExecutionType to rest_model and modify execution_type in OrderUpdate to use ExecutionType instead of OrderStatus.
Add Clone traits to OrderTradeUpdate/Order/PriceMatch/SelfTradePreventionMode.
Update to /fapi/v2/ticker/price for lower latency and /fapi/v1/ticker/price will be deprecated in the future.