### PR TITLE
futures: fix get_open_orders request not pass symbol

### DIFF
--- a/src/futures/account.rs
+++ b/src/futures/account.rs
@@ -78,7 +78,7 @@ impl FuturesAccount {
     }
 
     pub async fn get_open_orders(&self, symbol: impl Into<String>) -> Result<Vec<Order>> {
-        let payload = build_signed_request_p([("symbol", symbol.into())], self.recv_window)?;
+        let payload = build_signed_request_p(PairQuery{symbol: symbol.into()}, self.recv_window)?;
         self.client.get_signed("/fapi/v1/openOrders", &payload).await
     }
 


### PR DESCRIPTION
currently in get_open_orders() method the built request doesn't include symbol field which will cause the call always return all open orders of all symbols, I fixed it by changing into struct and now it can return open orders for specific symbol.