### PR TITLE
Remove order Id `b` and Seller order ID `a` from TradeEvent

### DIFF
--- a/src/ws_model.rs
+++ b/src/ws_model.rs
@@ -86,12 +86,6 @@ pub struct TradeEvent {
     #[serde(rename = "q")]
     pub qty: String,
 
-    #[serde(rename = "b")]
-    pub buyer_order_id: u64,
-
-    #[serde(rename = "a")]
-    pub seller_order_id: u64,
-
     #[serde(rename = "T")]
     pub trade_order_time: u64,
 


### PR DESCRIPTION
Fixes https://github.com/Igosuki/binance-rs-async/issues/139